### PR TITLE
StockTrader: sellall.script: Only kill broker.script

### DIFF
--- a/StockTrader/sellall.script
+++ b/StockTrader/sellall.script
@@ -11,7 +11,8 @@ symbols = ["ECP", "MGCP", "BLD", "CLRK", "OMTK",
            "CTYS", "MDYN", "TITN"
   ];
 
-killall();
+scriptKill("brokermanager.script", getHostname());
+scriptKill("broker.script", getHostname());
 
 // How many shares do I own
 ownedshares = getStockPosition(stock);


### PR DESCRIPTION
The killall() function will kill this sellall script as well, besides the others.
With this change you can also allow scripts unrelated to this broker to
remain alive.